### PR TITLE
Update quickstart.mdx

### DIFF
--- a/apps/docs/quickstart.mdx
+++ b/apps/docs/quickstart.mdx
@@ -43,7 +43,7 @@ The above command will start the Trench server that includes a local Clickhouse 
           }
         }]
     }' \
-     'https://sandbox.trench.dev/events'
+     'http://localhost:4000/events'
     ```
 
   </Step>
@@ -112,7 +112,7 @@ This will return a JSON response with the event that was just sent:
 
 ## Going Further
 
-While the above steps serves as a great starting point, the following video tutorial an example of the many things you can do with Trench. In this video, we build a mini version of Google Analytics using Trench and Grafana:
+While the above steps are a great starting point, the following video tutorial exemplifies the many things you can do with Trench. In this video, we build a mini version of Google Analytics using Trench and Grafana:
 
 <video
   controls


### PR DESCRIPTION
Hey!

The first example uses the wrong hostname. If people are to self-host the service, the URL is `http://localhost:4000/`, as with other examples in Quick Start.

Regards,

\- Oto