### PR TITLE
Fix: filter dates for clickhouse query

### DIFF
--- a/apps/trench/src/events/events.dao.ts
+++ b/apps/trench/src/events/events.dao.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import { ClickhouseService } from '../services/data/clickhouse/clickhouse.service'
-import { escapeString } from '../services/data/clickhouse/clickhouse.util'
+import { escapeString, formatToClickhouseDate } from '../services/data/clickhouse/clickhouse.util'
 import { Event, EventDTO, EventsQuery, PaginatedEventResponse } from './events.interface'
 import { KafkaService } from '../services/data/kafka/kafka.service'
 import { KafkaEventWithUUID } from '../services/data/kafka/kafka.interface'
@@ -73,10 +73,10 @@ export class EventsDao {
       }
     }
     if (startDate) {
-      conditions.push(`timestamp >= '${escapeString(new Date(startDate).toISOString())}'`)
+      conditions.push(`timestamp >= '${formatToClickhouseDate(new Date(startDate))}'`)
     }
     if (endDate) {
-      conditions.push(`timestamp <= '${escapeString(new Date(endDate).toISOString())}'`)
+      conditions.push(`timestamp <= '${formatToClickhouseDate(new Date(endDate))}'`)
     }
     if (uuid) {
       conditions.push(`uuid = '${escapeString(uuid)}'`)

--- a/apps/trench/src/services/data/clickhouse/clickhouse.util.ts
+++ b/apps/trench/src/services/data/clickhouse/clickhouse.util.ts
@@ -4,3 +4,15 @@ export function escapeString(str: string) {
     .replace(/'/g, "\\'") // Escape single quotes
     .replace(/"/g, '\\"') // Escape double quotes
 }
+
+/**
+ * Formats a date to be used in a ClickHouse query.
+ *
+ * The date will be formatted as ISO 8601, without the timezone "Z" at the end.
+ * The date will also be escaped to be safe to use in a ClickHouse query.
+ */
+export function formatToClickhouseDate(date: Date): string {
+  const isoString = date.toISOString();
+  const clickhouseDate = isoString.replace('Z', '');
+  return escapeString(clickhouseDate);
+}


### PR DESCRIPTION
Hey guys,
at first: good work. Trench is a really usefull and easy to setup project.
While testing the features i found a "bug" (don't know if its really a bug).

If i tried to filter between `startDate` and `endDate ` i got this error:
![image](https://github.com/user-attachments/assets/58559f40-1c4a-4217-9a6a-14bbc55d7c2d)

`date.toISOString()` returns the date with the Z for the timezone at the end and the `DateTime64(6, 'UTC')` method from clickhouse cannot convert this string. 
With this fix i added a utility function that cuts out the Z from the date string and formats it to an ISO 8601 date.
Feel free to decline this PR if its not a bug. 
