### PR TITLE
Fix: offset return type

### DIFF
--- a/apps/trench/src/events/events.dao.ts
+++ b/apps/trench/src/events/events.dao.ts
@@ -93,7 +93,7 @@ export class EventsDao {
     return {
       results: results,
       limit: maxRecords,
-      offset: offset ?? 0,
+      offset: +offset || 0,
       total: null,
     }
   }


### PR DESCRIPTION
The offset query parameter is inserted and returned as a string. Tested with insomnia:
![image](https://github.com/user-attachments/assets/c32d65f9-a028-4908-937f-c8fccad16053)

I fixed it as a one liner. Maybe we can make it more robust in the future. 
In case I have not tested it correctly, feel free to decline this PR. 
