### PR TITLE
Fix broken link on Cloud Quick Start

### DIFF
--- a/apps/docs/cloud-quickstart.mdx
+++ b/apps/docs/cloud-quickstart.mdx
@@ -8,7 +8,7 @@ import TrenchScript from '/snippets/trench-script.mdx';
 
 
 In this guide, we'll walk you through the process of sending your first event and reading it back using the Trench Cloud API.
-The example uses the [Trench JavaScript client](https://github.com/trench-dev/trench-js), but the same can be achieved by calling the [Events API](https://docs.trench.dev/api-reference/events-create) directly.
+The example uses the [Trench JavaScript client](https://www.npmjs.com/package/trench-js), but the same can be achieved by calling the [Events API](https://docs.trench.dev/api-reference/events-create) directly.
 
 ## Getting Started
 


### PR DESCRIPTION
On [Cloud QuickStart](https://docs.trench.dev/cloud-quickstart)
Trench JavaScript client points to https://github.com/trench-dev/trench-js
which I think should be https://www.npmjs.com/package/trench-js

Although I am not sure if I were to link the github repo, of npm package @christianmat 

For now I have linked the npm registry link