### PR TITLE
feat: Add Kafka SASL/SSL authentication support with ClickHouse integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,5 @@ ios/Pods
 !.yarn/plugins
 
 .turbo
+
+certs

--- a/README.md
+++ b/README.md
@@ -171,6 +171,64 @@ If you have questions or need assistance, you can join our [Slack group](https:/
    }
    ```
 
+### Kafka authentication
+
+Trench supports connecting to Kafka clusters that require SASL and/or SSL. Configure via the following environment variables (all optional):
+
+- `KAFKA_SSL_ENABLED`: Enable SSL/TLS when connecting to brokers. Values: `true`/`false` (default: `false`).
+- `KAFKA_SSL_REJECT_UNAUTHORIZED`: Whether to verify broker certificates. Values: `true`/`false` (default: `true`). Set to `false` when using self-signed certs in development.
+- `KAFKA_SSL_CA`: CA certificate contents (PEM). Use when brokers use a custom CA.
+- `KAFKA_SSL_CERT`: Client certificate contents (PEM) if mutual TLS is required.
+- `KAFKA_SSL_KEY`: Client private key (PEM) if mutual TLS is required.
+- `KAFKA_SASL_MECHANISM`: One of `plain`, `scram-sha-256`, or `scram-sha-512`.
+- `KAFKA_SASL_USERNAME`: SASL username (required when `KAFKA_SASL_MECHANISM` is set).
+- `KAFKA_SASL_PASSWORD`: SASL password (required when `KAFKA_SASL_MECHANISM` is set).
+- `CLICKHOUSE_APPLY_KAFKA_AUTH`: Whether to apply Kafka auth parameters in ClickHouse migrations. Values: `true`/`false` (default: `true`). Set to `false` if Kafka auth is configured in ClickHouse config files instead.
+
+Notes:
+- For SSL cert variables, provide the PEM content directly (including header/footer) or mount files and load into env before starting.
+- When using Bitnami Kafka images locally, the default `docker-compose.yml` uses PLAINTEXT; set the appropriate broker listeners and advertise SSL/SASL endpoints in your Kafka deployment if required.
+- The `CLICKHOUSE_APPLY_KAFKA_AUTH` flag controls whether Kafka authentication parameters are automatically added to ClickHouse Kafka engine tables during migrations. Set to `false` if you prefer to configure Kafka auth in ClickHouse configuration files.
+
+### Testing Kafka Authentication
+
+Trench includes additional Docker Compose files for testing different Kafka authentication scenarios:
+
+#### SASL-Only Authentication
+```bash
+# Test with SASL authentication (no SSL)
+docker-compose -f docker-compose.yml -f docker-compose.sasl.yml up --build
+```
+
+This setup uses:
+- `KAFKA_SASL_MECHANISM=PLAIN`
+- `KAFKA_SASL_USERNAME=kafka_user`
+- `KAFKA_SASL_PASSWORD=kafka_password`
+- `KAFKA_SSL_ENABLED=false`
+
+#### SSL+SASL Authentication
+```bash
+# Generate SSL certificates first
+./scripts/generate-kafka-certs.sh
+
+# Set environment variables for SSL certificates
+export KAFKA_SSL_CA=$(cat ./certs/ca.pem)
+export KAFKA_SSL_CERT=$(cat ./certs/client.pem)
+export KAFKA_SSL_KEY=$(cat ./certs/client.key)
+
+# Test with both SSL and SASL authentication
+docker-compose -f docker-compose.yml -f docker-compose.ssl-sasl.yml up --build
+```
+
+This setup uses:
+- `KAFKA_SSL_ENABLED=true`
+- `KAFKA_SSL_REJECT_UNAUTHORIZED=false` (for self-signed certs)
+- `KAFKA_SASL_MECHANISM=PLAIN`
+- `KAFKA_SASL_USERNAME=kafka_user`
+- `KAFKA_SASL_PASSWORD=kafka_password`
+
+Both test configurations automatically apply Kafka authentication parameters to ClickHouse migrations via `CLICKHOUSE_APPLY_KAFKA_AUTH=true`.
+
 ### 2. Trench Cloud ☁️
 
 If you don't want to selfhost, you can get started with Trench in a few minutes via:

--- a/README.md
+++ b/README.md
@@ -183,12 +183,15 @@ Trench supports connecting to Kafka clusters that require SASL and/or SSL. Confi
 - `KAFKA_SASL_MECHANISM`: One of `plain`, `scram-sha-256`, or `scram-sha-512`.
 - `KAFKA_SASL_USERNAME`: SASL username (required when `KAFKA_SASL_MECHANISM` is set).
 - `KAFKA_SASL_PASSWORD`: SASL password (required when `KAFKA_SASL_MECHANISM` is set).
-- `CLICKHOUSE_APPLY_KAFKA_AUTH`: Whether to apply Kafka auth parameters in ClickHouse migrations. Values: `true`/`false` (default: `true`). Set to `false` if Kafka auth is configured in ClickHouse config files instead.
 
 Notes:
 - For SSL cert variables, provide the PEM content directly (including header/footer) or mount files and load into env before starting.
 - When using Bitnami Kafka images locally, the default `docker-compose.yml` uses PLAINTEXT; set the appropriate broker listeners and advertise SSL/SASL endpoints in your Kafka deployment if required.
-- The `CLICKHOUSE_APPLY_KAFKA_AUTH` flag controls whether Kafka authentication parameters are automatically added to ClickHouse Kafka engine tables during migrations. Set to `false` if you prefer to configure Kafka auth in ClickHouse configuration files.
+- Kafka authentication for ClickHouse should be configured in ClickHouse server configuration files, not in SQL migrations.
+
+### ClickHouse Kafka Authentication
+
+For ClickHouse to connect to authenticated Kafka clusters, you need to configure authentication in ClickHouse server configuration files.
 
 ### 2. Trench Cloud ☁️
 
@@ -206,6 +209,44 @@ If you don't want to selfhost, you can get started with Trench in a few minutes 
 - [Website](https://trench.dev?utm_campaign=github-readme)
 - [Documentation](https://docs.trench.dev/)
 - [Slack community](https://join.slack.com/t/trench-community/shared_invite/zt-2sjet5kh2-v31As3yC_zRIadk_AGn~3A)
+
+### Kafka Authentication Examples
+
+Trench supports Kafka authentication with SASL and SSL. Here are examples of how to configure both Node.js KafkaJS client and ClickHouse for authenticated Kafka connections.
+
+**Quick Start:**
+- **SASL-only**: `docker compose -f docker-compose.sasl.yml up -d --build`
+- **SSL+SASL**: Generate certs first with `./scripts/generate-kafka-certs.sh`, then run the compose file
+
+#### SASL-Only Authentication
+```bash
+# Run with SASL authentication (no SSL)
+docker compose -f docker-compose.sasl.yml up -d --build
+```
+
+This setup uses:
+- **Node.js KafkaJS**: `KAFKA_SASL_MECHANISM=PLAIN`, `KAFKA_SASL_USERNAME=kafka_user`, `KAFKA_SASL_PASSWORD=kafka_password`
+- **ClickHouse**: Pre-configured with `clickhouse-kafka-auth-config-example/clickhouse-sasl.xml` for Kafka authentication
+- **Kafka**: SASL_PLAINTEXT listener on port 9095
+
+#### SSL+SASL Authentication
+```bash
+# Step 1: Generate SSL certificates
+./scripts/generate-kafka-certs.sh
+
+# Step 2: Set environment variables for SSL certificates
+export KAFKA_SSL_CA=$(cat ./certs/ca.pem)
+export KAFKA_SSL_CERT=$(cat ./certs/client.pem)
+export KAFKA_SSL_KEY=$(cat ./certs/client-key.pem)
+
+# Step 3: Run with both SSL and SASL authentication
+docker compose -f docker-compose.ssl-sasl.yml up -d --build
+```
+
+This setup uses:
+- **Node.js KafkaJS**: SSL+SASL authentication via environment variables
+- **ClickHouse**: Pre-configured with `clickhouse-kafka-auth-config-example/clickhouse-ssl-sasl.xml` for Kafka authentication
+- **Kafka**: SASL_SSL listener on port 9095 with SSL certificates
 
 ## 📚 Authors
 

--- a/README.md
+++ b/README.md
@@ -190,45 +190,6 @@ Notes:
 - When using Bitnami Kafka images locally, the default `docker-compose.yml` uses PLAINTEXT; set the appropriate broker listeners and advertise SSL/SASL endpoints in your Kafka deployment if required.
 - The `CLICKHOUSE_APPLY_KAFKA_AUTH` flag controls whether Kafka authentication parameters are automatically added to ClickHouse Kafka engine tables during migrations. Set to `false` if you prefer to configure Kafka auth in ClickHouse configuration files.
 
-### Testing Kafka Authentication
-
-Trench includes additional Docker Compose files for testing different Kafka authentication scenarios:
-
-#### SASL-Only Authentication
-```bash
-# Test with SASL authentication (no SSL)
-docker-compose -f docker-compose.yml -f docker-compose.sasl.yml up --build
-```
-
-This setup uses:
-- `KAFKA_SASL_MECHANISM=PLAIN`
-- `KAFKA_SASL_USERNAME=kafka_user`
-- `KAFKA_SASL_PASSWORD=kafka_password`
-- `KAFKA_SSL_ENABLED=false`
-
-#### SSL+SASL Authentication
-```bash
-# Generate SSL certificates first
-./scripts/generate-kafka-certs.sh
-
-# Set environment variables for SSL certificates
-export KAFKA_SSL_CA=$(cat ./certs/ca.pem)
-export KAFKA_SSL_CERT=$(cat ./certs/client.pem)
-export KAFKA_SSL_KEY=$(cat ./certs/client.key)
-
-# Test with both SSL and SASL authentication
-docker-compose -f docker-compose.yml -f docker-compose.ssl-sasl.yml up --build
-```
-
-This setup uses:
-- `KAFKA_SSL_ENABLED=true`
-- `KAFKA_SSL_REJECT_UNAUTHORIZED=false` (for self-signed certs)
-- `KAFKA_SASL_MECHANISM=PLAIN`
-- `KAFKA_SASL_USERNAME=kafka_user`
-- `KAFKA_SASL_PASSWORD=kafka_password`
-
-Both test configurations automatically apply Kafka authentication parameters to ClickHouse migrations via `CLICKHOUSE_APPLY_KAFKA_AUTH=true`.
-
 ### 2. Trench Cloud ☁️
 
 If you don't want to selfhost, you can get started with Trench in a few minutes via:

--- a/apps/trench/clickhouse-kafka-auth-config-example/clickhouse-sasl.xml
+++ b/apps/trench/clickhouse-kafka-auth-config-example/clickhouse-sasl.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<clickhouse>
+    <kafka>
+        <security_protocol>sasl_plaintext</security_protocol>
+        <sasl_mechanism>PLAIN</sasl_mechanism>
+        <sasl_username>kafka_user</sasl_username>
+        <sasl_password>kafka_password</sasl_password>
+    </kafka>
+</clickhouse>

--- a/apps/trench/clickhouse-kafka-auth-config-example/clickhouse-ssl-sasl.xml
+++ b/apps/trench/clickhouse-kafka-auth-config-example/clickhouse-ssl-sasl.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<clickhouse>
+    <kafka>
+        <security_protocol>sasl_ssl</security_protocol>
+        <sasl_mechanism>PLAIN</sasl_mechanism>
+        <sasl_username>kafka_user</sasl_username>
+        <sasl_password>kafka_password</sasl_password>
+        <enable_ssl_certificate_verification>false</enable_ssl_certificate_verification>
+    </kafka>
+</clickhouse>

--- a/apps/trench/docker-compose.sasl.yml
+++ b/apps/trench/docker-compose.sasl.yml
@@ -1,0 +1,82 @@
+services:
+  api:
+    build:
+      dockerfile: Dockerfile
+      context: .
+      target: production-build
+      args:
+        API_DOMAIN: ${API_DOMAIN}
+    env_file:
+      - .env
+    volumes:
+      - ./:/app
+      - /app/node_modules
+      - /app/certs
+      - /app/schemas
+      - /app/dist
+    command: node /app/dist/main.js -i -1
+    ports:
+      - '${API_PORT}:${API_PORT}'
+    depends_on:
+      - clickhouse
+      - kafka
+    networks:
+      - app-network
+    restart: unless-stopped
+    environment:
+      # Kafka SASL authentication (no SSL)
+      - KAFKA_SSL_ENABLED=false
+      - KAFKA_SASL_MECHANISM=PLAIN
+      - KAFKA_SASL_USERNAME=kafka_user
+      - KAFKA_SASL_PASSWORD=kafka_password
+      - CLICKHOUSE_APPLY_KAFKA_AUTH=true
+  clickhouse:
+    image: clickhouse/clickhouse-server
+    restart: always
+    ports:
+      - '8123:8123'
+      - '9000:9000'
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse # Data storage
+    environment:
+      - CLICKHOUSE_USER=${CLICKHOUSE_USER}
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    networks:
+      - app-network
+  kafka:
+    image: bitnami/kafka:latest
+    ports:
+      - 9092:9092
+      - 9093:9093
+      - 9094:9094
+    deploy:
+      resources:
+        limits:
+          cpus: '4'
+          memory: 4096M
+    environment:
+      - KAFKA_CFG_NODE_ID=0
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      # SASL_PLAINTEXT listeners (no SSL)
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,SASL_PLAINTEXT://:9095,EXTERNAL://:9094
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,SASL_PLAINTEXT://kafka:9095,EXTERNAL://localhost:9094
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,SASL_PLAINTEXT:SASL_PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      # SASL configuration
+      - KAFKA_CFG_SASL_ENABLED_MECHANISMS=PLAIN
+      - KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL=PLAIN
+      - KAFKA_CFG_SASL_JAAS_CONFIG=org.apache.kafka.common.security.plain.PlainLoginModule required username="kafka_user" password="kafka_password" user_kafka_user="kafka_password" user_admin="admin_password";
+    volumes:
+      - kafka-data:/bitnami/kafka
+    networks:
+      - app-network
+volumes:
+  clickhouse-data:
+  kafka-data:
+networks:
+  app-network:

--- a/apps/trench/docker-compose.sasl.yml
+++ b/apps/trench/docker-compose.sasl.yml
@@ -18,26 +18,33 @@ services:
     ports:
       - '${API_PORT}:${API_PORT}'
     depends_on:
-      - clickhouse
-      - kafka
+      kafka:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
     networks:
       - app-network
     restart: unless-stopped
     environment:
-      # Kafka SASL authentication (no SSL)
+      - KAFKA_BROKERS=kafka:9095
       - KAFKA_SSL_ENABLED=false
       - KAFKA_SASL_MECHANISM=PLAIN
       - KAFKA_SASL_USERNAME=kafka_user
       - KAFKA_SASL_PASSWORD=kafka_password
-      - CLICKHOUSE_APPLY_KAFKA_AUTH=true
   clickhouse:
-    image: clickhouse/clickhouse-server
+    image: clickhouse/clickhouse-server:24.8
     restart: always
+    healthcheck:
+      test: ["CMD", "bash", "-lc", "wget -qO- http://localhost:8123/ping | grep -q 'Ok'"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
     ports:
       - '8123:8123'
       - '9000:9000'
     volumes:
-      - clickhouse-data:/var/lib/clickhouse # Data storage
+      - clickhouse-data:/var/lib/clickhouse
+      - ./clickhouse-kafka-auth-config-example/clickhouse-sasl.xml:/etc/clickhouse-server/config.d/kafka.xml:ro
     environment:
       - CLICKHOUSE_USER=${CLICKHOUSE_USER}
       - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
@@ -48,11 +55,12 @@ services:
     networks:
       - app-network
   kafka:
-    image: bitnami/kafka:latest
+    image: bitnamilegacy/kafka:3.7.0
     ports:
       - 9092:9092
       - 9093:9093
       - 9094:9094
+      - 9095:9095
     deploy:
       resources:
         limits:
@@ -61,18 +69,28 @@ services:
     environment:
       - KAFKA_CFG_NODE_ID=0
       - KAFKA_CFG_PROCESS_ROLES=controller,broker
-      # SASL_PLAINTEXT listeners (no SSL)
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=1
       - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,SASL_PLAINTEXT://:9095,EXTERNAL://:9094
       - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,SASL_PLAINTEXT://kafka:9095,EXTERNAL://localhost:9094
       - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,SASL_PLAINTEXT:SASL_PLAINTEXT,EXTERNAL:PLAINTEXT
       - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
       - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
-      # SASL configuration
       - KAFKA_CFG_SASL_ENABLED_MECHANISMS=PLAIN
       - KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL=PLAIN
       - KAFKA_CFG_SASL_JAAS_CONFIG=org.apache.kafka.common.security.plain.PlainLoginModule required username="kafka_user" password="kafka_password" user_kafka_user="kafka_password" user_admin="admin_password";
+      - KAFKA_CFG_LISTENER_NAME_SASL_PLAINTEXT_SASL_ENABLED_MECHANISMS=PLAIN
+      - KAFKA_CFG_LISTENER_NAME_SASL_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG=org.apache.kafka.common.security.plain.PlainLoginModule required username="kafka_user" password="kafka_password" user_kafka_user="kafka_password" user_admin="admin_password";
     volumes:
       - kafka-data:/bitnami/kafka
+    healthcheck:
+      test: ["CMD", "bash", "-lc", "/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 60
     networks:
       - app-network
 volumes:

--- a/apps/trench/docker-compose.ssl-sasl.yml
+++ b/apps/trench/docker-compose.ssl-sasl.yml
@@ -1,0 +1,95 @@
+services:
+  api:
+    build:
+      dockerfile: Dockerfile
+      context: .
+      target: production-build
+      args:
+        API_DOMAIN: ${API_DOMAIN}
+    env_file:
+      - .env
+    volumes:
+      - ./:/app
+      - /app/node_modules
+      - /app/certs
+      - /app/schemas
+      - /app/dist
+    command: node /app/dist/main.js -i -1
+    ports:
+      - '${API_PORT}:${API_PORT}'
+    depends_on:
+      - clickhouse
+      - kafka
+    networks:
+      - app-network
+    restart: unless-stopped
+    environment:
+      # Kafka SSL+SASL authentication
+      - KAFKA_SSL_ENABLED=true
+      - KAFKA_SSL_REJECT_UNAUTHORIZED=false
+      - KAFKA_SSL_CA=${KAFKA_SSL_CA}
+      - KAFKA_SSL_CERT=${KAFKA_SSL_CERT}
+      - KAFKA_SSL_KEY=${KAFKA_SSL_KEY}
+      - KAFKA_SASL_MECHANISM=PLAIN
+      - KAFKA_SASL_USERNAME=kafka_user
+      - KAFKA_SASL_PASSWORD=kafka_password
+      - CLICKHOUSE_APPLY_KAFKA_AUTH=true
+  clickhouse:
+    image: clickhouse/clickhouse-server
+    restart: always
+    ports:
+      - '8123:8123'
+      - '9000:9000'
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse # Data storage
+    environment:
+      - CLICKHOUSE_USER=${CLICKHOUSE_USER}
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    networks:
+      - app-network
+  kafka:
+    image: bitnami/kafka:latest
+    ports:
+      - 9092:9092
+      - 9093:9093
+      - 9094:9094
+      - 9095:9095
+    deploy:
+      resources:
+        limits:
+          cpus: '4'
+          memory: 4096M
+    environment:
+      - KAFKA_CFG_NODE_ID=0
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      # SSL+SASL listeners
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,SASL_SSL://:9095,EXTERNAL://:9094
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,SASL_SSL://kafka:9095,EXTERNAL://localhost:9094
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,SASL_SSL:SASL_SSL,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      # SSL configuration
+      - KAFKA_CFG_SSL_KEYSTORE_LOCATION=/opt/bitnami/kafka/config/certs/kafka.server.keystore.jks
+      - KAFKA_CFG_SSL_KEYSTORE_PASSWORD=server_keystore_password
+      - KAFKA_CFG_SSL_KEY_PASSWORD=server_keystore_password
+      - KAFKA_CFG_SSL_TRUSTSTORE_LOCATION=/opt/bitnami/kafka/config/certs/kafka.server.truststore.jks
+      - KAFKA_CFG_SSL_TRUSTSTORE_PASSWORD=server_truststore_password
+      - KAFKA_CFG_SSL_CLIENT_AUTH=required
+      # SASL configuration
+      - KAFKA_CFG_SASL_ENABLED_MECHANISMS=PLAIN
+      - KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL=PLAIN
+      - KAFKA_CFG_SASL_JAAS_CONFIG=org.apache.kafka.common.security.plain.PlainLoginModule required username="kafka_user" password="kafka_password" user_kafka_user="kafka_password" user_admin="admin_password";
+    volumes:
+      - kafka-data:/bitnami/kafka
+      - ./certs:/opt/bitnami/kafka/config/certs:ro
+    networks:
+      - app-network
+volumes:
+  clickhouse-data:
+  kafka-data:
+networks:
+  app-network:

--- a/apps/trench/docker-compose.ssl-sasl.yml
+++ b/apps/trench/docker-compose.ssl-sasl.yml
@@ -18,13 +18,15 @@ services:
     ports:
       - '${API_PORT}:${API_PORT}'
     depends_on:
-      - clickhouse
-      - kafka
+      kafka:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
     networks:
       - app-network
     restart: unless-stopped
     environment:
-      # Kafka SSL+SASL authentication
+      - KAFKA_BROKERS=kafka:9095
       - KAFKA_SSL_ENABLED=true
       - KAFKA_SSL_REJECT_UNAUTHORIZED=false
       - KAFKA_SSL_CA=${KAFKA_SSL_CA}
@@ -33,15 +35,21 @@ services:
       - KAFKA_SASL_MECHANISM=PLAIN
       - KAFKA_SASL_USERNAME=kafka_user
       - KAFKA_SASL_PASSWORD=kafka_password
-      - CLICKHOUSE_APPLY_KAFKA_AUTH=true
   clickhouse:
-    image: clickhouse/clickhouse-server
+    image: clickhouse/clickhouse-server:24.8
     restart: always
+    healthcheck:
+      test: ["CMD", "bash", "-lc", "clickhouse-client --query 'SELECT 1'"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
     ports:
       - '8123:8123'
       - '9000:9000'
     volumes:
-      - clickhouse-data:/var/lib/clickhouse # Data storage
+      - clickhouse-data:/var/lib/clickhouse
+      - ./clickhouse-kafka-auth-config-example/clickhouse-ssl-sasl.xml:/etc/clickhouse-server/config.d/kafka.xml:ro
+      - ./certs:/opt/bitnami/kafka/config/certs:ro
     environment:
       - CLICKHOUSE_USER=${CLICKHOUSE_USER}
       - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
@@ -52,7 +60,7 @@ services:
     networks:
       - app-network
   kafka:
-    image: bitnami/kafka:latest
+    image: bitnamilegacy/kafka:3.7.0
     ports:
       - 9092:9092
       - 9093:9093
@@ -66,26 +74,35 @@ services:
     environment:
       - KAFKA_CFG_NODE_ID=0
       - KAFKA_CFG_PROCESS_ROLES=controller,broker
-      # SSL+SASL listeners
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=1
       - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,SASL_SSL://:9095,EXTERNAL://:9094
       - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,SASL_SSL://kafka:9095,EXTERNAL://localhost:9094
       - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,SASL_SSL:SASL_SSL,EXTERNAL:PLAINTEXT
       - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
       - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
-      # SSL configuration
-      - KAFKA_CFG_SSL_KEYSTORE_LOCATION=/opt/bitnami/kafka/config/certs/kafka.server.keystore.jks
+      - KAFKA_CFG_SSL_KEYSTORE_LOCATION=/opt/bitnami/kafka/config/certs/kafka.keystore.jks
       - KAFKA_CFG_SSL_KEYSTORE_PASSWORD=server_keystore_password
       - KAFKA_CFG_SSL_KEY_PASSWORD=server_keystore_password
-      - KAFKA_CFG_SSL_TRUSTSTORE_LOCATION=/opt/bitnami/kafka/config/certs/kafka.server.truststore.jks
+      - KAFKA_CFG_SSL_TRUSTSTORE_LOCATION=/opt/bitnami/kafka/config/certs/kafka.truststore.jks
       - KAFKA_CFG_SSL_TRUSTSTORE_PASSWORD=server_truststore_password
       - KAFKA_CFG_SSL_CLIENT_AUTH=required
-      # SASL configuration
       - KAFKA_CFG_SASL_ENABLED_MECHANISMS=PLAIN
       - KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL=PLAIN
       - KAFKA_CFG_SASL_JAAS_CONFIG=org.apache.kafka.common.security.plain.PlainLoginModule required username="kafka_user" password="kafka_password" user_kafka_user="kafka_password" user_admin="admin_password";
+      - KAFKA_CFG_LISTENER_NAME_SASL_SSL_SASL_ENABLED_MECHANISMS=PLAIN
+      - KAFKA_CFG_LISTENER_NAME_SASL_SSL_PLAIN_SASL_JAAS_CONFIG=org.apache.kafka.common.security.plain.PlainLoginModule required username="kafka_user" password="kafka_password" user_kafka_user="kafka_password" user_admin="admin_password";
     volumes:
       - kafka-data:/bitnami/kafka
       - ./certs:/opt/bitnami/kafka/config/certs:ro
+    healthcheck:
+      test: ["CMD", "bash", "-lc", "/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 60
     networks:
       - app-network
 volumes:

--- a/apps/trench/docker-compose.yml
+++ b/apps/trench/docker-compose.yml
@@ -23,8 +23,10 @@ services:
     networks:
       - app-network
     restart: unless-stopped
+    environment:
+      - KAFKA_BROKERS=kafka:9092
   clickhouse:
-    image: clickhouse/clickhouse-server
+    image: clickhouse/clickhouse-server:24.8
     restart: always
     ports:
       - '8123:8123'
@@ -42,7 +44,7 @@ services:
     networks:
       - app-network
   kafka:
-    image: bitnami/kafka:latest
+    image: bitnamilegacy/kafka:3.7.0
     ports:
       - 9092:9092
       - 9093:9093

--- a/apps/trench/scripts/generate-kafka-certs.sh
+++ b/apps/trench/scripts/generate-kafka-certs.sh
@@ -12,82 +12,57 @@ TRUSTSTORE_PASSWORD="server_truststore_password"
 echo "Creating certificates directory..."
 mkdir -p "$CERT_DIR"
 
+echo "Generating CA private key..."
+openssl genrsa -out "$CERT_DIR/ca-key.pem" 2048
+
 echo "Generating CA certificate..."
-openssl req -new -x509 -keyout "$CERT_DIR/ca-key" -out "$CERT_DIR/ca-cert" -days 365 -nodes \
+openssl req -new -x509 -key "$CERT_DIR/ca-key.pem" -out "$CERT_DIR/ca.pem" -days 365 \
     -subj "/C=US/ST=CA/L=SF/O=Trench/OU=IT Department/CN=ca"
 
-echo "Generating server keystore..."
-keytool -keystore "$CERT_DIR/kafka.server.keystore.jks" -alias kafka-server -validity 365 -genkey -keyalg RSA \
-    -dname "CN=kafka, OU=Trench, O=Trench, L=SF, S=CA, C=US" \
-    -storepass "$KEYSTORE_PASSWORD" -keypass "$KEYSTORE_PASSWORD"
-
-echo "Adding CA certificate to server keystore..."
-keytool -keystore "$CERT_DIR/kafka.server.keystore.jks" -alias CARoot -import -file "$CERT_DIR/ca-cert" \
-    -storepass "$KEYSTORE_PASSWORD" -noprompt
+echo "Generating server private key..."
+openssl genrsa -out "$CERT_DIR/server-key.pem" 2048
 
 echo "Generating server certificate signing request..."
-keytool -keystore "$CERT_DIR/kafka.server.keystore.jks" -alias kafka-server -certreq -file "$CERT_DIR/server.csr" \
-    -storepass "$KEYSTORE_PASSWORD"
+openssl req -new -key "$CERT_DIR/server-key.pem" -out "$CERT_DIR/server.csr" \
+    -subj "/C=US/ST=CA/L=SF/O=Trench/OU=IT Department/CN=kafka"
 
 echo "Signing server certificate with CA..."
-openssl x509 -req -CA "$CERT_DIR/ca-cert" -CAkey "$CERT_DIR/ca-key" -in "$CERT_DIR/server.csr" \
-    -out "$CERT_DIR/server.crt" -days 365 -CAcreateserial
+openssl x509 -req -in "$CERT_DIR/server.csr" -CA "$CERT_DIR/ca.pem" -CAkey "$CERT_DIR/ca-key.pem" \
+    -out "$CERT_DIR/server.pem" -days 365 -CAcreateserial
 
-echo "Importing signed certificate to server keystore..."
-keytool -keystore "$CERT_DIR/kafka.server.keystore.jks" -alias kafka-server -import -file "$CERT_DIR/server.crt" \
-    -storepass "$KEYSTORE_PASSWORD" -noprompt
-
-echo "Creating server truststore..."
-keytool -keystore "$CERT_DIR/kafka.server.truststore.jks" -alias CARoot -import -file "$CERT_DIR/ca-cert" \
-    -storepass "$TRUSTSTORE_PASSWORD" -noprompt
-
-echo "Generating client keystore..."
-keytool -keystore "$CERT_DIR/kafka.client.keystore.jks" -alias kafka-client -validity 365 -genkey -keyalg RSA \
-    -dname "CN=kafka-client, OU=Trench, O=Trench, L=SF, S=CA, C=US" \
-    -storepass "$KEYSTORE_PASSWORD" -keypass "$KEYSTORE_PASSWORD"
-
-echo "Adding CA certificate to client keystore..."
-keytool -keystore "$CERT_DIR/kafka.client.keystore.jks" -alias CARoot -import -file "$CERT_DIR/ca-cert" \
-    -storepass "$KEYSTORE_PASSWORD" -noprompt
+echo "Generating client private key..."
+openssl genrsa -out "$CERT_DIR/client-key.pem" 2048
 
 echo "Generating client certificate signing request..."
-keytool -keystore "$CERT_DIR/kafka.client.keystore.jks" -alias kafka-client -certreq -file "$CERT_DIR/client.csr" \
-    -storepass "$KEYSTORE_PASSWORD"
+openssl req -new -key "$CERT_DIR/client-key.pem" -out "$CERT_DIR/client.csr" \
+    -subj "/C=US/ST=CA/L=SF/O=Trench/OU=IT Department/CN=kafka-client"
 
 echo "Signing client certificate with CA..."
-openssl x509 -req -CA "$CERT_DIR/ca-cert" -CAkey "$CERT_DIR/ca-key" -in "$CERT_DIR/client.csr" \
-    -out "$CERT_DIR/client.crt" -days 365 -CAcreateserial
+openssl x509 -req -in "$CERT_DIR/client.csr" -CA "$CERT_DIR/ca.pem" -CAkey "$CERT_DIR/ca-key.pem" \
+    -out "$CERT_DIR/client.pem" -days 365 -CAcreateserial
 
-echo "Importing signed certificate to client keystore..."
-keytool -keystore "$CERT_DIR/kafka.client.keystore.jks" -alias kafka-client -import -file "$CERT_DIR/client.crt" \
-    -storepass "$KEYSTORE_PASSWORD" -noprompt
+echo "Creating server keystore (JKS format for Kafka)..."
+# Convert server cert to PKCS12 first
+openssl pkcs12 -export -in "$CERT_DIR/server.pem" -inkey "$CERT_DIR/server-key.pem" \
+    -out "$CERT_DIR/server.p12" -name kafka-server -passout pass:"$KEYSTORE_PASSWORD"
 
-echo "Creating client truststore..."
-keytool -keystore "$CERT_DIR/kafka.client.truststore.jks" -alias CARoot -import -file "$CERT_DIR/ca-cert" \
+# Convert to JKS
+keytool -importkeystore -srckeystore "$CERT_DIR/server.p12" -srcstoretype PKCS12 \
+    -destkeystore "$CERT_DIR/kafka.keystore.jks" -deststoretype JKS \
+    -srcstorepass "$KEYSTORE_PASSWORD" -deststorepass "$KEYSTORE_PASSWORD" -noprompt
+
+echo "Creating server truststore (JKS format for Kafka)..."
+keytool -import -file "$CERT_DIR/ca.pem" -alias ca -keystore "$CERT_DIR/kafka.truststore.jks" \
     -storepass "$TRUSTSTORE_PASSWORD" -noprompt
 
-echo "Converting certificates to PEM format for environment variables..."
-# Convert CA cert to PEM
-keytool -keystore "$CERT_DIR/kafka.server.truststore.jks" -alias CARoot -export -rfc -file "$CERT_DIR/ca.pem" \
-    -storepass "$TRUSTSTORE_PASSWORD"
-
-# Extract client cert and key to PEM
-keytool -keystore "$CERT_DIR/kafka.client.keystore.jks" -alias kafka-client -export -rfc -file "$CERT_DIR/client.pem" \
-    -storepass "$KEYSTORE_PASSWORD"
-
-# Extract private key (requires openssl)
-keytool -keystore "$CERT_DIR/kafka.client.keystore.jks" -alias kafka-client -importkeystore -srckeystore "$CERT_DIR/kafka.client.keystore.jks" -destkeystore "$CERT_DIR/client.p12" -deststoretype PKCS12 -srcstorepass "$KEYSTORE_PASSWORD" -deststorepass "$KEYSTORE_PASSWORD" -noprompt
-openssl pkcs12 -in "$CERT_DIR/client.p12" -nocerts -out "$CERT_DIR/client.key" -passin pass:"$KEYSTORE_PASSWORD" -passout pass:"$KEYSTORE_PASSWORD"
-openssl rsa -in "$CERT_DIR/client.key" -out "$CERT_DIR/client.key" -passin pass:"$KEYSTORE_PASSWORD"
-
 echo "Cleaning up temporary files..."
-rm -f "$CERT_DIR/server.csr" "$CERT_DIR/client.csr" "$CERT_DIR/server.crt" "$CERT_DIR/client.crt" "$CERT_DIR/client.p12" "$CERT_DIR/client.key"
+rm -f "$CERT_DIR/server.csr" "$CERT_DIR/client.csr" "$CERT_DIR/server.p12" "$CERT_DIR/ca.srl"
 
 echo "Certificate generation complete!"
 echo ""
-echo "For SSL+SASL testing, set these environment variables:"
+echo "For SSL+SASL setup, set these environment variables:"
 echo "export KAFKA_SSL_CA=\$(cat $CERT_DIR/ca.pem)"
 echo "export KAFKA_SSL_CERT=\$(cat $CERT_DIR/client.pem)"
-echo "export KAFKA_SSL_KEY=\$(cat $CERT_DIR/client.key)"
+echo "export KAFKA_SSL_KEY=\$(cat $CERT_DIR/client.key.pem)"
 echo ""
-echo "Then run: docker-compose -f docker-compose.ssl-sasl.yml up --build"
+echo "Then run: docker compose -f docker-compose.ssl-sasl.yml up -d --build"

--- a/apps/trench/scripts/generate-kafka-certs.sh
+++ b/apps/trench/scripts/generate-kafka-certs.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Generate SSL certificates for Kafka SSL+SASL testing
+# This script creates self-signed certificates for local testing
+
+set -e
+
+CERT_DIR="./certs"
+KEYSTORE_PASSWORD="server_keystore_password"
+TRUSTSTORE_PASSWORD="server_truststore_password"
+
+echo "Creating certificates directory..."
+mkdir -p "$CERT_DIR"
+
+echo "Generating CA certificate..."
+openssl req -new -x509 -keyout "$CERT_DIR/ca-key" -out "$CERT_DIR/ca-cert" -days 365 -nodes \
+    -subj "/C=US/ST=CA/L=SF/O=Trench/OU=IT Department/CN=ca"
+
+echo "Generating server keystore..."
+keytool -keystore "$CERT_DIR/kafka.server.keystore.jks" -alias kafka-server -validity 365 -genkey -keyalg RSA \
+    -dname "CN=kafka, OU=Trench, O=Trench, L=SF, S=CA, C=US" \
+    -storepass "$KEYSTORE_PASSWORD" -keypass "$KEYSTORE_PASSWORD"
+
+echo "Adding CA certificate to server keystore..."
+keytool -keystore "$CERT_DIR/kafka.server.keystore.jks" -alias CARoot -import -file "$CERT_DIR/ca-cert" \
+    -storepass "$KEYSTORE_PASSWORD" -noprompt
+
+echo "Generating server certificate signing request..."
+keytool -keystore "$CERT_DIR/kafka.server.keystore.jks" -alias kafka-server -certreq -file "$CERT_DIR/server.csr" \
+    -storepass "$KEYSTORE_PASSWORD"
+
+echo "Signing server certificate with CA..."
+openssl x509 -req -CA "$CERT_DIR/ca-cert" -CAkey "$CERT_DIR/ca-key" -in "$CERT_DIR/server.csr" \
+    -out "$CERT_DIR/server.crt" -days 365 -CAcreateserial
+
+echo "Importing signed certificate to server keystore..."
+keytool -keystore "$CERT_DIR/kafka.server.keystore.jks" -alias kafka-server -import -file "$CERT_DIR/server.crt" \
+    -storepass "$KEYSTORE_PASSWORD" -noprompt
+
+echo "Creating server truststore..."
+keytool -keystore "$CERT_DIR/kafka.server.truststore.jks" -alias CARoot -import -file "$CERT_DIR/ca-cert" \
+    -storepass "$TRUSTSTORE_PASSWORD" -noprompt
+
+echo "Generating client keystore..."
+keytool -keystore "$CERT_DIR/kafka.client.keystore.jks" -alias kafka-client -validity 365 -genkey -keyalg RSA \
+    -dname "CN=kafka-client, OU=Trench, O=Trench, L=SF, S=CA, C=US" \
+    -storepass "$KEYSTORE_PASSWORD" -keypass "$KEYSTORE_PASSWORD"
+
+echo "Adding CA certificate to client keystore..."
+keytool -keystore "$CERT_DIR/kafka.client.keystore.jks" -alias CARoot -import -file "$CERT_DIR/ca-cert" \
+    -storepass "$KEYSTORE_PASSWORD" -noprompt
+
+echo "Generating client certificate signing request..."
+keytool -keystore "$CERT_DIR/kafka.client.keystore.jks" -alias kafka-client -certreq -file "$CERT_DIR/client.csr" \
+    -storepass "$KEYSTORE_PASSWORD"
+
+echo "Signing client certificate with CA..."
+openssl x509 -req -CA "$CERT_DIR/ca-cert" -CAkey "$CERT_DIR/ca-key" -in "$CERT_DIR/client.csr" \
+    -out "$CERT_DIR/client.crt" -days 365 -CAcreateserial
+
+echo "Importing signed certificate to client keystore..."
+keytool -keystore "$CERT_DIR/kafka.client.keystore.jks" -alias kafka-client -import -file "$CERT_DIR/client.crt" \
+    -storepass "$KEYSTORE_PASSWORD" -noprompt
+
+echo "Creating client truststore..."
+keytool -keystore "$CERT_DIR/kafka.client.truststore.jks" -alias CARoot -import -file "$CERT_DIR/ca-cert" \
+    -storepass "$TRUSTSTORE_PASSWORD" -noprompt
+
+echo "Converting certificates to PEM format for environment variables..."
+# Convert CA cert to PEM
+keytool -keystore "$CERT_DIR/kafka.server.truststore.jks" -alias CARoot -export -rfc -file "$CERT_DIR/ca.pem" \
+    -storepass "$TRUSTSTORE_PASSWORD"
+
+# Extract client cert and key to PEM
+keytool -keystore "$CERT_DIR/kafka.client.keystore.jks" -alias kafka-client -export -rfc -file "$CERT_DIR/client.pem" \
+    -storepass "$KEYSTORE_PASSWORD"
+
+# Extract private key (requires openssl)
+keytool -keystore "$CERT_DIR/kafka.client.keystore.jks" -alias kafka-client -importkeystore -srckeystore "$CERT_DIR/kafka.client.keystore.jks" -destkeystore "$CERT_DIR/client.p12" -deststoretype PKCS12 -srcstorepass "$KEYSTORE_PASSWORD" -deststorepass "$KEYSTORE_PASSWORD" -noprompt
+openssl pkcs12 -in "$CERT_DIR/client.p12" -nocerts -out "$CERT_DIR/client.key" -passin pass:"$KEYSTORE_PASSWORD" -passout pass:"$KEYSTORE_PASSWORD"
+openssl rsa -in "$CERT_DIR/client.key" -out "$CERT_DIR/client.key" -passin pass:"$KEYSTORE_PASSWORD"
+
+echo "Cleaning up temporary files..."
+rm -f "$CERT_DIR/server.csr" "$CERT_DIR/client.csr" "$CERT_DIR/server.crt" "$CERT_DIR/client.crt" "$CERT_DIR/client.p12" "$CERT_DIR/client.key"
+
+echo "Certificate generation complete!"
+echo ""
+echo "For SSL+SASL testing, set these environment variables:"
+echo "export KAFKA_SSL_CA=\$(cat $CERT_DIR/ca.pem)"
+echo "export KAFKA_SSL_CERT=\$(cat $CERT_DIR/client.pem)"
+echo "export KAFKA_SSL_KEY=\$(cat $CERT_DIR/client.key)"
+echo ""
+echo "Then run: docker-compose -f docker-compose.ssl-sasl.yml up --build"

--- a/apps/trench/src/services/data/click-house/click-house.service.ts
+++ b/apps/trench/src/services/data/click-house/click-house.service.ts
@@ -41,63 +41,11 @@ export class ClickHouseService {
     const kafkaInstanceId = md5(kafkaBrokerList + kafkaTopicList).slice(0, 6)
     const kafkaPartitions = process.env.KAFKA_PARTITIONS ?? DEFAULT_KAFKA_PARTITIONS
 
-    let result = sql
+    return sql
       .replaceAll('{kafka_brokers}', kafkaBrokerList)
       .replaceAll('{kafka_topic}', kafkaTopicList)
       .replaceAll('{kafka_instance_id}', kafkaInstanceId)
       .replaceAll('{kafka_partitions}', kafkaPartitions.toString())
-
-    const applyKafkaAuth = (process.env.CLICKHOUSE_APPLY_KAFKA_AUTH ?? 'true').toLowerCase() === 'true'
-    
-    if (applyKafkaAuth) {
-      const sslEnabled = (process.env.KAFKA_SSL_ENABLED ?? '').toLowerCase() === 'true'
-      const sslRejectUnauthorized = (process.env.KAFKA_SSL_REJECT_UNAUTHORIZED ?? 'true').toLowerCase() === 'true'
-      
-      const saslMechanism = process.env.KAFKA_SASL_MECHANISM
-      const saslUsername = process.env.KAFKA_SASL_USERNAME
-      const saslPassword = process.env.KAFKA_SASL_PASSWORD
-      
-      let securityProtocol = 'plaintext'
-      if (sslEnabled && saslMechanism) {
-        securityProtocol = 'sasl_ssl'
-      } else if (sslEnabled) {
-        securityProtocol = 'ssl'
-      } else if (saslMechanism) {
-        securityProtocol = 'sasl_plaintext'
-      }
-
-      let authSettings = ''
-      
-      if (securityProtocol !== 'plaintext') {
-        authSettings += `,\n    kafka_security_protocol = '${securityProtocol}'`
-      }
-      
-      if (saslMechanism && saslUsername && saslPassword) {
-        authSettings += `,\n    kafka_sasl_mechanism = '${saslMechanism}'`
-        authSettings += `,\n    kafka_sasl_username = '${saslUsername}'`
-        authSettings += `,\n    kafka_sasl_password = '${saslPassword}'`
-      }
-      
-      if (sslEnabled) {
-        if (process.env.KAFKA_SSL_CA) {
-          authSettings += `,\n    kafka_ssl_ca_cert = '${process.env.KAFKA_SSL_CA}'`
-        }
-        if (process.env.KAFKA_SSL_CERT) {
-          authSettings += `,\n    kafka_ssl_client_cert = '${process.env.KAFKA_SSL_CERT}'`
-        }
-        if (process.env.KAFKA_SSL_KEY) {
-          authSettings += `,\n    kafka_ssl_client_key = '${process.env.KAFKA_SSL_KEY}'`
-        }
-        authSettings += `,\n    kafka_ssl_reject_unauthorized = ${sslRejectUnauthorized}`
-      }
-
-      result = result.replace(
-        /kafka_num_consumers = {kafka_partitions}/,
-        `kafka_num_consumers = {kafka_partitions}${authSettings}`
-      )
-    }
-
-    return result
   }
 
   async runMigrations(databaseName?: string, kafkaTopicName?: string) {

--- a/apps/trench/src/services/data/click-house/click-house.service.ts
+++ b/apps/trench/src/services/data/click-house/click-house.service.ts
@@ -41,11 +41,63 @@ export class ClickHouseService {
     const kafkaInstanceId = md5(kafkaBrokerList + kafkaTopicList).slice(0, 6)
     const kafkaPartitions = process.env.KAFKA_PARTITIONS ?? DEFAULT_KAFKA_PARTITIONS
 
-    return sql
+    let result = sql
       .replaceAll('{kafka_brokers}', kafkaBrokerList)
       .replaceAll('{kafka_topic}', kafkaTopicList)
       .replaceAll('{kafka_instance_id}', kafkaInstanceId)
       .replaceAll('{kafka_partitions}', kafkaPartitions.toString())
+
+    const applyKafkaAuth = (process.env.CLICKHOUSE_APPLY_KAFKA_AUTH ?? 'true').toLowerCase() === 'true'
+    
+    if (applyKafkaAuth) {
+      const sslEnabled = (process.env.KAFKA_SSL_ENABLED ?? '').toLowerCase() === 'true'
+      const sslRejectUnauthorized = (process.env.KAFKA_SSL_REJECT_UNAUTHORIZED ?? 'true').toLowerCase() === 'true'
+      
+      const saslMechanism = process.env.KAFKA_SASL_MECHANISM
+      const saslUsername = process.env.KAFKA_SASL_USERNAME
+      const saslPassword = process.env.KAFKA_SASL_PASSWORD
+      
+      let securityProtocol = 'plaintext'
+      if (sslEnabled && saslMechanism) {
+        securityProtocol = 'sasl_ssl'
+      } else if (sslEnabled) {
+        securityProtocol = 'ssl'
+      } else if (saslMechanism) {
+        securityProtocol = 'sasl_plaintext'
+      }
+
+      let authSettings = ''
+      
+      if (securityProtocol !== 'plaintext') {
+        authSettings += `,\n    kafka_security_protocol = '${securityProtocol}'`
+      }
+      
+      if (saslMechanism && saslUsername && saslPassword) {
+        authSettings += `,\n    kafka_sasl_mechanism = '${saslMechanism}'`
+        authSettings += `,\n    kafka_sasl_username = '${saslUsername}'`
+        authSettings += `,\n    kafka_sasl_password = '${saslPassword}'`
+      }
+      
+      if (sslEnabled) {
+        if (process.env.KAFKA_SSL_CA) {
+          authSettings += `,\n    kafka_ssl_ca_cert = '${process.env.KAFKA_SSL_CA}'`
+        }
+        if (process.env.KAFKA_SSL_CERT) {
+          authSettings += `,\n    kafka_ssl_client_cert = '${process.env.KAFKA_SSL_CERT}'`
+        }
+        if (process.env.KAFKA_SSL_KEY) {
+          authSettings += `,\n    kafka_ssl_client_key = '${process.env.KAFKA_SSL_KEY}'`
+        }
+        authSettings += `,\n    kafka_ssl_reject_unauthorized = ${sslRejectUnauthorized}`
+      }
+
+      result = result.replace(
+        /kafka_num_consumers = {kafka_partitions}/,
+        `kafka_num_consumers = {kafka_partitions}${authSettings}`
+      )
+    }
+
+    return result
   }
 
   async runMigrations(databaseName?: string, kafkaTopicName?: string) {

--- a/apps/trench/src/services/data/kafka/kafka.service.ts
+++ b/apps/trench/src/services/data/kafka/kafka.service.ts
@@ -11,9 +11,45 @@ export class KafkaService {
   private producer: Producer
 
   constructor() {
+    const sslEnabled = (process.env.KAFKA_SSL_ENABLED ?? '').toLowerCase() === 'true'
+    const sslRejectUnauthorizedEnv = (process.env.KAFKA_SSL_REJECT_UNAUTHORIZED ?? '').toLowerCase()
+    const sslRejectUnauthorized = sslRejectUnauthorizedEnv
+      ? sslRejectUnauthorizedEnv === 'true'
+      : true
+
+    const hasSslMaterial = Boolean(
+      process.env.KAFKA_SSL_CA || process.env.KAFKA_SSL_CERT || process.env.KAFKA_SSL_KEY
+    )
+
+    const sslConfig = sslEnabled
+      ? hasSslMaterial
+        ? {
+            rejectUnauthorized: sslRejectUnauthorized,
+            ca: process.env.KAFKA_SSL_CA ? [process.env.KAFKA_SSL_CA] : undefined,
+            cert: process.env.KAFKA_SSL_CERT || undefined,
+            key: process.env.KAFKA_SSL_KEY || undefined,
+          }
+        : true
+      : undefined
+
+    const saslMechanism = (process.env.KAFKA_SASL_MECHANISM ?? '').toLowerCase()
+    const hasSaslCreds = Boolean(
+      saslMechanism && process.env.KAFKA_SASL_USERNAME && process.env.KAFKA_SASL_PASSWORD
+    )
+
+    const saslConfig = hasSaslCreds
+      ? {
+          mechanism: saslMechanism as any, // 'plain' | 'scram-sha-256' | 'scram-sha-512'
+          username: process.env.KAFKA_SASL_USERNAME,
+          password: process.env.KAFKA_SASL_PASSWORD,
+        }
+      : undefined
+
     this.kafka = new Kafka({
       clientId: process.env.KAFKA_CLIENT_ID ?? DEFAULT_KAFKA_CLIENT_ID,
       brokers: process.env.KAFKA_BROKERS.split(','),
+      ssl: sslConfig,
+      sasl: saslConfig,
     })
     this.producer = this.kafka.producer()
     this.connectToProducer()


### PR DESCRIPTION
## Summary
This PR adds comprehensive Kafka authentication support to Trench, including both SASL and SSL/TLS encryption options. The implementation ensures that authentication parameters are automatically applied to both the Node.js KafkaJS client and ClickHouse Kafka engine tables during migrations.

## Changes Made

### 🔐 Kafka Authentication Support
- **SASL Authentication**: Support for `PLAIN`, `SCRAM-SHA-256`, and `SCRAM-SHA-512` mechanisms
- **SSL/TLS Encryption**: Configurable SSL with custom CA, client certificates, and key validation
- **Environment Variables**: Comprehensive set of `KAFKA_*` environment variables for configuration
- **Security Defaults**: Both SSL and SASL are disabled by default

### 🗄️ ClickHouse Integration
- **Backward Compatibility**: Existing deployments continue to work without changes

### 🧪 Testing Infrastructure
- **SASL-Only Testing**: `docker-compose.sasl.yml` for testing SASL authentication without SSL
- **SSL+SASL Testing**: `docker-compose.ssl-sasl.yml` for testing full security stack
- **Certificate Generation**: `scripts/generate-kafka-certs.sh` for creating self-signed SSL certificates
- **Comprehensive Documentation**: Updated README with usage examples

## New Environment Variables

### Kafka Authentication
- `KAFKA_SSL_ENABLED`: Enable SSL/TLS (default: `false`)
- `KAFKA_SSL_REJECT_UNAUTHORIZED`: Certificate validation (default: `true`)
- `KAFKA_SSL_CA`: CA certificate (PEM format)
- `KAFKA_SSL_CERT`: Client certificate (PEM format)
- `KAFKA_SSL_KEY`: Client private key (PEM format)
- `KAFKA_SASL_MECHANISM`: SASL mechanism (`plain`, `scram-sha-256`, `scram-sha-512`)
- `KAFKA_SASL_USERNAME`: SASL username
- `KAFKA_SASL_PASSWORD`: SASL password

## Testing

### SASL-Only Authentication
```bash
docker compose -f docker-compose.sasl.yml up -d --build
```

### SSL+SASL Authentication
```bash
./scripts/generate-kafka-certs.sh
export KAFKA_SSL_CA=$(cat ./certs/ca.pem)
export KAFKA_SSL_CERT=$(cat ./certs/client.pem)
export KAFKA_SSL_KEY=$(cat ./certs/client.key)
docker compose -f docker-compose.ssl-sasl.yml up -d --build
```
